### PR TITLE
📦 Add linksafe action

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,12 @@
+name: Link-check
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run linksafe
+        uses: TechWiz-3/linksafe@fast
+        env:
+          TOKEN: ${{ secrets.TOKEN }}


### PR DESCRIPTION
First of all, thank you for your work on this project.

In this PR, I have added a workflow which checks links and fails if any of them are broken.

Disclaimer: this action is my own, the repo is [here](https://github.com/TechWiz-3/linksafe/tree/fast).
Because of the huge volume of links, I'm using the 'fast' version/branch which simply requires a GitHub token (with no extra perms) to be stored as a repo secret under the name  `TOKEN`. This is for requests to the GitHub API to avoid rate-limits. More setup info [here](https://github.com/TechWiz-3/linksafe/tree/fast#setup)

You can view the logs of the workflow on my fork [here](https://github.com/TechWiz-3/awesome-ruby/runs/8054273211?check_suite_focus=true#step:4:1987). 2 links were found to be broken.

Let me know if you'd like me to change anything, any feedback is appreciated either way :)